### PR TITLE
Strip documentation comments from CombatManager and BGM

### DIFF
--- a/client/BGM.ts
+++ b/client/BGM.ts
@@ -2,9 +2,6 @@ import Phaser from "phaser";
 import { DEFAULT_FADE_TIME, Sound, soundTracks } from "./utils/constants";
 import { USER } from "./User";
 
-/**
- * Sentinel object.
- */
 class NullAudio {
     public play() {
         throw new Error("Audio is currently null");
@@ -25,27 +22,10 @@ type Audio =
     | Phaser.Sound.WebAudioSound
     | NullAudio;
 
-/**
- * An object of this class manages the background music for all scenes in the game.
- */
 class BGMManager {
-    /** This audio object interfaces with Phaser's audio APIs. */
     private audio: Audio = new NullAudio();
     private currMusic: Sound = Sound.SILENCE;
 
-    /**
-     * Stops and destroys music that may currently be playing
-     * and starts playing the music specific by `music`.
-     *
-     * If the music isn't found, plays nothing.
-     * If `music` is currently being played, calling this method will
-     * restart it, unless `fromStart` is set to false.
-     *
-     * @param scene current scene
-     * @param music key indicating which soundtrack to play
-     * @param fromStart if false, then attempting to play music that's already
-     *      playing will do nothing. Otherwise, music will always play from the beginning.
-     */
     public play(scene: Phaser.Scene, music: Sound, fromStart = true): void {
         if (!fromStart && this.currMusic === music) {
             return;
@@ -63,17 +43,10 @@ class BGMManager {
         }
     }
 
-    /**
-     * Sets audio volume to 0.
-     */
     public hideMusic() {
         this.audio.setVolume(0);
     }
 
-    /**
-     * Restores music volume to the proper level (i.e. the level specified by the
-     * soundtrack most recently passed to the `play` method)
-     */
     public restoreMusic() {
         console.log("restoring music");
         const soundData = soundTracks.get(this.currMusic);
@@ -83,12 +56,6 @@ class BGMManager {
         }
     }
 
-    /**
-     * Fades the currently playing audio to 0 volume.
-     *
-     * @param scene
-     * @param duration how long the fadeout should take. By default, it's `DEFAULT_FADE_TIME`.
-     */
     public fadeOut(scene: Phaser.Scene, duration = DEFAULT_FADE_TIME) {
         scene.tweens.add({
             targets: this.audio,

--- a/client/CombatManager.ts
+++ b/client/CombatManager.ts
@@ -18,19 +18,6 @@ export interface ICombatManager {
     removeParticipant(name: string): void;
     processAttack(attacker: CanBeHit, attackData: AttackData): void;
 
-    /**
-     * Enters a projectile into the combat system: sets up checker that determines
-     * if the projectile has hit (intersects) any of the combatants in the system
-     * and enacts the appropriate damage/effects. The checker calls projectile handlers `onInit`
-     * and `onUpdate` appropriately.
-     *
-     * @param projectile
-     * @param projectileTeam team name used to determine projectile's targets/non-targets
-     * @param attackData
-     * @param onProjectileHit callback executed when the projectile has hit at least one target.
-     * @returns the process number of the intersection checker; call `clearInterval` on it when
-     *      the projectile should no longer be able to strike targets.
-     */
     registerProjectile(
         projectile: Projectile,
         projectileTeam: string,
@@ -38,25 +25,17 @@ export interface ICombatManager {
         onProjectileHit?: () => void
     ): number;
 
-    /**
-     * @returns Projectile handlers `onInit`, `onUpdate`, and `onRemove`, to be called
-     *      on creating the projectile, on each projectile frame update, and on projecile removal
-     *      (removal here means literally when the sprite needs to be destroyed).
-     */
     getProjectileHandlers(): ProjectileHandlers;
 }
-/**
- * Class for managing attacks between in-game combatants (player-controlled or not).
- */
+
 class CombatManager implements ICombatManager {
-    /** Maps participants to "team names". Friendly fire is disallowed. */
     private teams: Map<
         CanBeHit,
         { team: string; onHit?: (dmg: number) => void }
     > = new Map();
-    /** Maps participant names to participants. */
     private nameTracker: Map<string, CanBeHit> = new Map();
     private projectileHandlers = voidProjectileHandlers;
+
     public getTeam(name: string): string | null {
         const participant = this.nameTracker.get(name);
         if (participant === undefined) return null;
@@ -68,18 +47,6 @@ class CombatManager implements ICombatManager {
         return res.team;
     }
 
-    /**
-     * Adds a combatant. Adding a combatant this way only guarantees that it can be hit.
-     * For its attacks to be relayed to the rest of the combatants, use the `processAttack` method,
-     * See also the `Player` class's `registerAsCombatant` method.
-     *
-     * @param participant if a participant with the same name has already been added, then
-     *      this call will override the previous one.
-     * @param team name used to determine which participants should be able to hit each other.
-     *      Friendly fire is disallowed.
-     * @param onHit optional callback executed when this participant takes damage (immediately
-     *      after its `takeDamage` method is called).
-     */
     public addParticipant(
         participant: CanBeHit,
         team: string,
@@ -89,17 +56,11 @@ class CombatManager implements ICombatManager {
         this.nameTracker.set(participant.name, participant);
     }
 
-    /** Removes the participant with the given name. */
     public removeParticipant(name: string) {
         const participant = this.nameTracker.get(name);
         if (participant !== undefined) this.teams.delete(participant);
     }
-    /**
-     *
-     * @param attacker
-     * @param dmg amount of damage dealt by attack
-     * @param aoe indicates whether attack strikes everybody in range.
-     */
+
     public processAttack(attacker: CanBeHit, attack: AttackData) {
         const { damage, aoe } = attack;
         const attackerObj = this.teams.get(attacker);
@@ -115,9 +76,6 @@ class CombatManager implements ICombatManager {
         }
     }
 
-    /**
-     * Updates the projectile handlers.
-     */
     public setProjectileHandler(handlers: {
         onUpdate: (projectile: HasLocation) => void;
         onInit: (projectile: HasLocation) => void;
@@ -125,6 +83,7 @@ class CombatManager implements ICombatManager {
     }) {
         this.projectileHandlers = handlers;
     }
+
     public getProjectileHandlers() {
         return this.projectileHandlers;
     }
@@ -192,19 +151,8 @@ class NullCombatManager implements ICombatManager {
 }
 
 export interface ProjectileHandlers {
-    /**
-     * Method to be called on each frame update of `projectile`.
-     */
     onUpdate(projectile: HasLocation): void;
-    /**
-     * Method to be called when the projectile is created.
-     */
     onInit(projetile: HasLocation): void;
-    /**
-     * Callback to be executed the moment the projectile sprite needs to be destroyed.
-     * Note that the combat manager does not handle projectile removal,
-     * so clients will need to call this method themselves.
-     */
     onRemove(projectile: HasLocation): void;
 }
 


### PR DESCRIPTION
Purged all JSDoc-style and inline documentation comments from:
• client/CombatManager.ts
• client/BGM.ts
This retains full functionality while meeting the request to remove docs.